### PR TITLE
feat: automate Helm chart releases with helm-semver

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -1,0 +1,29 @@
+name: Release Helm Chart
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "helm/**"
+
+jobs:
+  release-chart:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # needed for helm-semver to push version bump commits and tags
+      packages: write # needed to push chart to GHCR
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # helm-semver needs full git history for commit scanning
+
+      - name: Release chart to GHCR
+        uses: rhysmcneill/helm-semver@v1
+        with:
+          charts-dir: helm
+          registry: oci://ghcr.io/${{ github.repository_owner }}/helm-charts
+          changelog: "true"
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -3,7 +3,7 @@ name: Release Helm Chart
 on:
   push:
     branches:
-      - main
+      - master
     paths:
       - "helm/**"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,3 +130,45 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  sync-chart-appversion:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # needed to push commits and tags
+      packages: write # needed to push chart to GHCR
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # helm-semver needs full git history for commit scanning
+
+      - name: Sync appVersion and release Helm chart
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ needs.build-and-push.outputs.version }}"
+          CHART_FILE="helm/vagrantfile-generator/Chart.yaml"
+
+          # 1. Bump appVersion in Chart.yaml
+          echo "Updating appVersion in $CHART_FILE to $VERSION"
+          sed -i "s/^appVersion:.*/appVersion: \"$VERSION\"/" "$CHART_FILE"
+
+          # 2. Commit the appVersion bump so helm-semver can detect it
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "$CHART_FILE"
+          git commit -m "fix: sync chart appVersion to $VERSION"
+
+          # 3. Run helm-semver: bumps chart version, packages, pushes to GHCR,
+          #    commits the version bump + changelog, creates git tag, and pushes.
+          docker run --rm \
+            -v "$PWD:/workspace" \
+            -e GITHUB_TOKEN \
+            ghcr.io/rhysmcneill/helm-semver:latest \
+            release \
+            --charts-dir helm \
+            --registry oci://ghcr.io/${{ github.repository_owner }}/helm-charts \
+            --git-author-name "github-actions[bot]" \
+            --git-author-email "github-actions[bot]@users.noreply.github.com"
+

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ See [docs/dev/local-setup.md](./docs/dev/local-setup.md) for full development se
 - **Shared Resources**: See [docs/user/SHARED_RESOURCES.md](./docs/user/SHARED_RESOURCES.md)
 - **Development**: See [docs/dev/local-setup.md](./docs/dev/local-setup.md) for native development setup
 - **Environments**: See [docs/dev/environments.md](./docs/dev/environments.md) for dev, Compose, and Helm roles
+- **Helm Chart**: Published to `oci://ghcr.io/marekruzicka/helm-charts/vagrantfile-generator`. Releases are automated via [helm-semver](https://github.com/rhysmcneill/helm-semver) — see [helm.mk](./helm.mk) for local usage.
 - **Issues**: Report bugs and feature requests through [GitHub Issues](https://github.com/marekruzicka/vagrantfile-generator/issues)
 
 ## License

--- a/docs/dev/environments.md
+++ b/docs/dev/environments.md
@@ -7,7 +7,7 @@ Vagrantfile Generator has separate paths for development, self-hosted quick star
 | Native dev          | `setup-local-dev.sh`, VS Code tasks | Active development             |
 | Self-hosted Compose | `compose.yml`                       | End-user quick-start (prebuilt images) |
 | Compose dev build   | `compose-dev.yml` + Makefile        | Local image build/smoke test   |
-| Public production   | Helm chart                          | Hosted Kubernetes deployment   |
+| Public production   | Helm chart ([helm-semver](https://github.com/rhysmcneill/helm-semver)) | Hosted Kubernetes deployment   |
 
 ## Native Dev
 
@@ -55,7 +55,13 @@ make clean  # removes volumes too
 
 ## Public Production
 
-Use the Helm chart for Kubernetes deployments with authentication enabled. Requires:
+Use the Helm chart for Kubernetes deployments with authentication enabled.
+
+Chart releases are automated via [helm-semver](https://github.com/rhysmcneill/helm-semver):
+- **CI (GHCR)**: Every push to `main` touching `helm/` triggers a chart release to `oci://ghcr.io/marekruzicka/helm-charts`.
+- **Local (testing)**: Run `make helm-semver-release-local` to release to a local OCI registry.
+
+Requires:
 
 - `DEPLOYMENT_MODE=public`
 - `JWT_SECRET` and `SESSION_COOKIE_SECRET`

--- a/helm.mk
+++ b/helm.mk
@@ -27,7 +27,7 @@ OCI_PATH     ?= oci://$(OCI_REGISTRY)/vgf
 # Extra flags for self-signed / internal registries
 HELM_INSECURE ?= --insecure
 
-.PHONY: helm-lint helm-package helm-push helm-release helm-login helm-dry-run clean-helm
+.PHONY: helm-lint helm-package helm-push helm-release helm-login helm-dry-run clean-helm helm-semver-install helm-semver-dry-run helm-semver-release-local
 
 # ---------------------------------------------------------------------------
 # Targets
@@ -75,3 +75,41 @@ helm-dry-run:
 clean-helm:
 	@echo "Removing packaged charts..."
 	rm -f $(CHART_NAME)-*.tgz
+
+# ---------------------------------------------------------------------------
+# helm-semver (automated semver release tool)
+# ---------------------------------------------------------------------------
+# Requires: helm-semver (https://github.com/rhysmcneill/helm-semver)
+#
+# Install with: make helm-semver-install
+# Or run via Docker: docker run --rm -v $(PWD):/workspace ghcr.io/rhysmcneill/helm-semver:latest release ...
+
+HELM_SEMVER ?= $(shell command -v helm-semver 2>/dev/null || echo "docker run --rm -v $(PWD):/workspace ghcr.io/rhysmcneill/helm-semver:latest")
+
+## Install helm-semver binary locally (Linux/macOS)
+helm-semver-install:
+	@if command -v helm-semver >/dev/null 2>&1; then \
+		echo "helm-semver already installed: $$(helm-semver version)"; \
+	else \
+		echo "Installing helm-semver..."; \
+		OS=$$(uname -s | tr '[:upper:]' '[:lower:]'); \
+		ARCH=$$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/'); \
+		URL="https://github.com/rhysmcneill/helm-semver/releases/latest/download/helm-semver-$$OS-$$ARCH"; \
+		curl -fsSL "$$URL" -o /usr/local/bin/helm-semver && chmod +x /usr/local/bin/helm-semver; \
+		echo "helm-semver installed successfully"; \
+	fi
+
+## Dry-run: preview what helm-semver would release to local registry
+helm-semver-dry-run:
+	$(HELM_SEMVER) release \
+		--charts-dir helm \
+		--registry $(OCI_PATH) \
+		--registry-type oci \
+		--dry-run
+
+## Release chart to local registry using helm-semver (for testing)
+helm-semver-release-local:
+	$(HELM_SEMVER) release \
+		--charts-dir helm \
+		--registry $(OCI_PATH) \
+		--registry-type oci


### PR DESCRIPTION
## Summary

Replace manual Helm chart versioning with [helm-semver](https://github.com/rhysmcneill/helm-semver) — automated semver releases driven by conventional commits.

## Changes

### New: `.github/workflows/helm-release.yml`
Triggered on every push to `master` that touches `helm/**`. Runs helm-semver which:
- Scans conventional commits since the last chart tag
- Bumps chart `version` (`fix:` → patch, `feat:` → minor, `feat!:` → major)
- Packages and pushes to `oci://ghcr.io/marekruzicka/helm-charts`
- Commits the bump, creates a chart tag (`vagrantfile-generator-vX.Y.Z`), pushes

### Updated: `.github/workflows/release.yml`
New `sync-chart-appversion` job (runs after Docker builds):
1. Updates `appVersion` in Chart.yaml to the new release version
2. Commits with `fix: sync chart appVersion to X.Y.Z` prefix
3. Runs helm-semver directly (Docker image) to release the chart

### Updated: `helm.mk`
Three new targets for local use:
- `make helm-semver-install` — download the binary
- `make helm-semver-dry-run` — preview release to local registry
- `make helm-semver-release-local` — full release to local registry (testing)

### Updated: docs
- `README.md` — Helm chart + helm-semver link
- `docs/dev/environments.md` — CI and local usage documented

## Architecture

```
Chart-only change (feat(helm): ...)     App release (tag v1.15.0)
        |                                        |
        v                                        v
  Push to master                        release.yml builds images
        |                                        |
        v                                        v
  helm-release.yml                     sync-chart-appversion job
  helm-semver                           bumps appVersion, commits
  bumps version, pushes to GHCR         runs helm-semver (inline)
        |                                        |
        +------------ both push to GHCR ---------+
```

## First run

No chart tags exist yet. First run scans all commits touching `helm/` — the `feat(helm): support existingClaim` commit means `0.3.0 → 0.4.0`.