### PR TITLE
ci: consolidate Helm release flow

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Create tag if new version in CHANGELOG
         env:
           CHART_RELEASE_PAT: ${{ secrets.CHART_RELEASE_PAT }}
-        run: |
+        run: | #shell
           VERSION=$(grep -m1 '^## Version' CHANGELOG.md | awk '{print $3}')
           if [ -z "$VERSION" ]; then
             echo "No version header found in CHANGELOG.md — nothing to tag"

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Detect changed files
         id: changed-files
-        run: |
+        run: | #shell
           BEFORE="${{ github.event.before }}"
           AFTER="${{ github.sha }}"
           ZERO_SHA="0000000000000000000000000000000000000000"

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -1,11 +1,18 @@
 name: Release Helm Chart
 
+# Single Helm publishing flow.
+# Triggered by either chart-only changes under helm/** or by release.yml syncing
+# Chart.yaml appVersion after an app release.
 on:
   push:
     branches:
       - master
     paths:
       - "helm/**"
+
+concurrency:
+  group: helm-release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   release-chart:

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -3,6 +3,10 @@ name: Release Helm Chart
 # Single Helm publishing flow.
 # Triggered by either chart-only changes under helm/** or by release.yml syncing
 # Chart.yaml appVersion after an app release.
+#
+# If a push changes both CHANGELOG.md and helm/**, skip the immediate chart-only
+# release. auto-tag.yml will create the app tag, release.yml will sync Chart.yaml
+# appVersion, and that follow-up helm/** commit will trigger this workflow once.
 on:
   push:
     branches:
@@ -15,7 +19,44 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      changelog-changed: ${{ steps.changed-files.outputs.changelog-changed }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed files
+        id: changed-files
+        run: |
+          BEFORE="${{ github.event.before }}"
+          AFTER="${{ github.sha }}"
+          ZERO_SHA="0000000000000000000000000000000000000000"
+
+          if [ "$BEFORE" = "$ZERO_SHA" ]; then
+            git diff-tree --no-commit-id --name-only -r "$AFTER" > changed-files.txt
+          else
+            git diff --name-only "$BEFORE" "$AFTER" > changed-files.txt
+          fi
+
+          echo "Changed files:"
+          cat changed-files.txt
+
+          if grep -qx 'CHANGELOG.md' changed-files.txt; then
+            echo "changelog-changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changelog-changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
   release-chart:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.changelog-changed != 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write # needed for helm-semver to push version bump commits and tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,10 +41,10 @@ jobs:
           fetch-depth: 0
 
       - name: Set up QEMU (for multi-arch builds)
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Determine version and tag
         id: vars
@@ -63,11 +63,11 @@ jobs:
             TAG="$REF"
             VERSION="${TAG#v}"
           fi
-          echo "TAG=$TAG" >> $GITHUB_OUTPUT
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "TAG=$TAG" >> "$GITHUB_OUTPUT"
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -115,9 +115,11 @@ jobs:
           # trim leading blank lines
           sed -i '1{/^$/d;}' release_notes.md
           # write to GITHUB_OUTPUT
-          echo "notes<<EOF" >> $GITHUB_OUTPUT
-          cat release_notes.md >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          {
+            echo "notes<<EOF"
+            cat release_notes.md
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Create or update GitHub release
         uses: softprops/action-gh-release@v2
@@ -134,44 +136,33 @@ jobs:
     needs: build-and-push
     runs-on: ubuntu-latest
     permissions:
-      contents: write # needed to push commits and tags
-      packages: write # needed to push chart to GHCR
+      contents: write # needed to push the appVersion sync commit
 
     steps:
-      - name: Checkout
+      - name: Checkout master
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # helm-semver needs full git history for commit scanning
+          ref: master
+          fetch-depth: 0
+          token: ${{ secrets.CHART_RELEASE_PAT }}
 
-      - name: Sync appVersion and release Helm chart
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Sync chart appVersion
         run: |
           VERSION="${{ needs.build-and-push.outputs.version }}"
           CHART_FILE="helm/vagrantfile-generator/Chart.yaml"
 
-          # 1. Bump appVersion in Chart.yaml
           echo "Updating appVersion in $CHART_FILE to $VERSION"
           sed -i "s/^appVersion:.*/appVersion: \"$VERSION\"/" "$CHART_FILE"
 
-          # 2. Commit the appVersion bump so helm-semver can detect it
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add "$CHART_FILE"
-          git commit -m "fix: sync chart appVersion to $VERSION"
 
-          # 3. Run helm-semver: bumps chart version, packages, pushes to GHCR,
-          #    commits the version bump + changelog, creates git tag, and pushes.
-          docker run --rm \
-            -v "$PWD:/workspace" \
-            -e GIT_TOKEN="${{ secrets.CHART_RELEASE_PAT }}" \
-            ghcr.io/rhysmcneill/helm-semver:latest \
-            release \
-            --charts-dir helm \
-            --registry oci://ghcr.io/${{ github.repository_owner }}/helm-charts \
-            --registry-username "${{ github.repository_owner }}" \
-            --registry-password "${{ secrets.GITHUB_TOKEN }}" \
-            --git-token "${{ secrets.CHART_RELEASE_PAT }}" \
-            --git-author-name "github-actions[bot]" \
-            --git-author-email "github-actions[bot]@users.noreply.github.com"
+          if git diff --cached --quiet; then
+            echo "Chart appVersion already up to date"
+            exit 0
+          fi
+
+          git commit -m "fix(helm): sync chart appVersion to $VERSION"
+          git push origin HEAD:master
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,7 +147,7 @@ jobs:
           token: ${{ secrets.CHART_RELEASE_PAT }}
 
       - name: Sync chart appVersion
-        run: |
+        run: | #shell
           VERSION="${{ needs.build-and-push.outputs.version }}"
           CHART_FILE="helm/vagrantfile-generator/Chart.yaml"
 


### PR DESCRIPTION
## Summary
- make `.github/workflows/helm-release.yml` the single Helm publishing flow
- change app release workflow to only sync chart `appVersion`, then let the Helm workflow publish the chart
- skip immediate chart-only release when the same push also changes `CHANGELOG.md` to avoid duplicate Helm releases
- update Docker GitHub Actions to current major versions and fix actionlint shellcheck findings

## Validation
- `source ~/.profile && actionlint`
- YAML parse check for all workflow files
- `git diff --check`

## Notes
After merging, rerun/backfill the failed 1.14.2 release from the fixed workflow, or merge a dedicated `appVersion: "1.14.2"` chart-sync change if you want the lighter recovery path.