### PR TITLE
Fix auto-tag release workflow trigger

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -15,6 +15,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # Do not persist GITHUB_TOKEN credentials; tag pushes made with
+          # GITHUB_TOKEN do not trigger downstream workflows. The release
+          # tag must be pushed with CHART_RELEASE_PAT below.
+          persist-credentials: false
 
       - name: Create tag if new version in CHANGELOG
         env:


### PR DESCRIPTION
## Summary

- Disable persisted checkout credentials in the auto-tag workflow.
- Ensure release tags are pushed with `CHART_RELEASE_PAT` instead of `GITHUB_TOKEN`.
- Allow tag pushes to trigger the downstream **Build, Publish & Release** workflow.

## Context

The `v1.14.3` tag was created, but the release workflow did not start because pushes authenticated with `GITHUB_TOKEN` do not trigger additional workflows.

This PR makes sure the tag push uses the configured PAT so future changelog-driven tags trigger the release workflow correctly.

## Validation

- Manually dispatched the missed `1.14.3` release successfully.
- Confirmed the follow-up Helm chart release completed successfully.
