### PR TITLE
fix(frontend): theme toggle not working on authenticated dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## Version 1.14.5
 
 ### 🐛 Bug Fixes
 
@@ -255,7 +255,6 @@
 ### ✨ New Features
 
 - **Collapsible Sections**: Improved content organization and navigation
-
   - All major sections (Plugins, Provisioners, Triggers, VMs) can now be collapsed/expanded
   - Toggle sections by clicking either the chevron icon or the section name
   - Smooth expand/collapse transitions with visual feedback
@@ -264,7 +263,6 @@
   - Available on both Project Detail and Settings pages (8 collapsible sections total)
 
 - **Enhanced Main Page Layout**: More compact and efficient use of screen space
-
   - Reduced header padding and spacing for less whitespace
   - Added global statistics cards showing total Plugins, Provisioners, and Triggers
   - Implemented 6-column responsive grid layout for statistics cards
@@ -282,14 +280,12 @@
 ### 🎨 UI/UX Improvements
 
 - **Better Interaction Design**: More intuitive and accessible controls
-
   - Section headers are now fully clickable, not just the chevron buttons
   - Hover states provide clear visual feedback on interactive elements
   - Reduced visual clutter by removing unnecessary subtitle text from cards
   - Progressive disclosure pattern improves navigation with large datasets
 
 - **Modal Enhancements**: Standardized and improved modal experiences
-
   - Trigger modal now uses checkmark icon instead of plus sign (consistent with other modals)
   - Enhanced empty states with X icons for better visual communication
   - Improved button consistency across all modals
@@ -316,7 +312,6 @@
 ### ✨ New Features
 
 - **Global Provisioner Management**: Add and configure Vagrant provisioners for your projects
-
   - Manage shell provisioners through the Settings page
   - Add, edit, and delete provisioner configurations
   - Configure shell scripts, privilege levels, and run modes (once/always)
@@ -324,7 +319,6 @@
   - View provisioner descriptions and details
 
 - **Project-Level Provisioner Configuration**: Assign provisioners to individual projects
-
   - Add multiple provisioners to any project from the project detail page
   - Multiselect modal with checkbox-based selection for adding multiple provisioners at once
   - Visual provisioner cards showing name, type, and description
@@ -335,7 +329,6 @@
   - Provisioners are organized in the Settings page, separate from plugins
 
 - **Enhanced Plugin Management**: Improved plugin workflow and UX
-
   - **Smart Filtering**: Plugin modal now only shows plugins not yet added to the project
   - **Edit from Project Detail**: Edit plugins directly from the project detail page without navigating away
   - **Improved Error Handling**: Better feedback when plugins already exist or fail to add
@@ -375,14 +368,12 @@
 ### ✨ New Features
 
 - **Global Plugin Management**: Add and configure Vagrant plugins for your projects
-
   - Manage plugins through the Settings page
   - Add, edit, and delete plugin configurations
   - Set default versions and mark deprecated plugins
   - View plugin descriptions and details
 
 - **Project-Level Plugin Configuration**: Assign plugins to individual projects
-
   - Add multiple plugins to any project from the project detail page
   - Visual plugin cards showing name, version, and status
   - Bulk selection and deletion of plugins
@@ -390,7 +381,6 @@
   - Simple empty state when no plugins are configured
 
 - **Enhanced Vagrantfile Generation**: Generated Vagrantfiles now include plugin configurations
-
   - Plugins are automatically added to the Vagrant configuration
   - Version constraints are respected
   - Proper Ruby syntax with color-coded highlighting in preview modal
@@ -415,7 +405,6 @@
 ### ✨ New Features
 
 - **Configurable Footer**: View changelog, documentation, and external links from the footer
-
   - Click footer links to view content in a modal window
   - External links open in new tabs automatically
   - Markdown documents displayed with proper formatting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### 🐛 Bug Fixes
+
+- **Dashboard theme toggle**: Fixed theme toggle button not working on the authenticated dashboard after sign-in. Alpine.js directives on dynamically loaded HTML partials were never bound; added `Alpine.initTree()` re-initialization after partial injection.
+
+---
+
 ## Version 1.14.4
 
 **Date:** June 26, 2026

--- a/frontend/src/js/utils/html-loader.js
+++ b/frontend/src/js/utils/html-loader.js
@@ -36,6 +36,9 @@ class HTMLLoader {
             const html = await this.loadPartial(path);
             element.innerHTML = html;
             element.removeAttribute('data-include-html');
+            if (typeof Alpine !== 'undefined' && Alpine.initTree) {
+                Alpine.initTree(element);
+            }
         }
     }
 
@@ -44,6 +47,9 @@ class HTMLLoader {
         if (modalContainer) {
             const html = await this.loadPartial(path);
             modalContainer.innerHTML = html;
+            if (typeof Alpine !== 'undefined' && Alpine.initTree) {
+                Alpine.initTree(modalContainer);
+            }
         }
     }
 }

--- a/frontend/tests/e2e/dashboard-theme-toggle.spec.ts
+++ b/frontend/tests/e2e/dashboard-theme-toggle.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from '@playwright/test'
+
+async function themeColor(page) {
+  return page.locator('meta[name="theme-color"]').getAttribute('content')
+}
+
+test.describe('dashboard theme toggle', () => {
+  test('header toggle switches and persists dark mode after sign in', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('vfg-theme', 'light')
+    })
+
+    await page.goto('/')
+    await expect(
+      page.getByRole('heading', { name: /your vagrant projects/i })
+    ).toBeVisible()
+
+    const cookieBanner = page.locator('#vfg-cookie-banner')
+    if (await cookieBanner.isVisible().catch(() => false)) {
+      await cookieBanner.getByRole('button', { name: /^dismiss$/i }).click()
+    }
+
+    await expect(page.locator('html')).not.toHaveClass(/\bdark\b/)
+    await expect.poll(() => themeColor(page)).toBe('#3b82f6')
+
+    const toggle = page.getByRole('button', { name: /toggle dark mode/i })
+    await expect(toggle).toBeVisible()
+    await toggle.click()
+
+    await expect(page.locator('html')).toHaveClass(/\bdark\b/)
+    await expect.poll(() => themeColor(page)).toBe('#1e293b')
+    await expect
+      .poll(() => page.evaluate(() => localStorage.getItem('vfg-theme')))
+      .toBe('dark')
+
+    await toggle.click()
+
+    await expect(page.locator('html')).not.toHaveClass(/\bdark\b/)
+    await expect.poll(() => themeColor(page)).toBe('#3b82f6')
+    await expect
+      .poll(() => page.evaluate(() => localStorage.getItem('vfg-theme')))
+      .toBe('light')
+  })
+})


### PR DESCRIPTION
## Summary

Fixes the theme toggle button on the authenticated dashboard (app page). The button was visible but clicking it had no effect because Alpine.js directives on dynamically loaded HTML partials were never compiled.

## Root Cause

Alpine.js initializes the DOM before `DOMContentLoaded` (due to `defer`), but HTML partials (including the header with `@click` theme toggle) are injected via `innerHTML` during `DOMContentLoaded`. Alpine never re-processed the dynamically inserted HTML — zero `Alpine.initTree()` calls existed in the codebase. The landing page toggle worked because it used native `onclick=""`, not Alpine directives.

## Fix

Added `Alpine.initTree(element)` guarded with `typeof Alpine !== 'undefined'` after every `innerHTML` injection in `html-loader.js`. This re-initializes Alpine on all dynamically loaded partials (header, projects list, project detail, modals, footer, notifications).

## Tests

- New E2E test: `dashboard-theme-toggle.spec.ts` — verifies toggle switches dark/light mode and persists preference — ✅ passes on chromium + firefox
- Existing regression: `dark-mode.spec.ts` (landing page toggle) — ✅ passes on no-auth
- Full suite: 124 passed, 5 skipped, 1 pre-existing flaky (unrelated Firefox VM test)

## Risks / Notes

- Minimal risk. The `Alpine.initTree()` call is guarded against pages without Alpine (landing page, login page).
- Alpine's `initTree` is a no-op on already-processed elements, so no double-binding risk.
- Fixes the entire class of bugs for all dynamically loaded Alpine directives, not just the theme toggle.

## Changelog

- Updated `CHANGELOG.md`.
