### PR TITLE
fix: redirect OIDC callback to /index.html?token= so nginx serves the SPA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Version 1.16.1
+
+### 🐛 Bug Fixes
+
+- **OIDC callback redirect serving landing page instead of SPA**: After nginx was configured with a `location = /` block serving `landing.html` (commit b683a43), the OIDC callback redirect to `{frontend_url}/?token={jwt_token}` hit that exact-match rule and served the landing page — which has no token-handling JavaScript — instead of `index.html` (the SPA). Changed the redirect URL to `/index.html?token=...` so nginx serves the SPA, and `main.js` correctly picks up the token, stores it in `localStorage`, and completes the authentication flow. Both the SPA and the legacy login page (`/views/login/login.html`) are covered.
+
+---
+
 ## Version 1.16.0
 
 ### ✨ New Features

--- a/backend/src/api/auth.py
+++ b/backend/src/api/auth.py
@@ -278,7 +278,7 @@ async def oidc_callback(
         from starlette.responses import RedirectResponse
 
         frontend_url = os.getenv("FRONTEND_URL", "http://localhost:8080")
-        redirect_url = f"{frontend_url}/?token={jwt_token}"
+        redirect_url = f"{frontend_url}/index.html?token={jwt_token}"
         return RedirectResponse(url=redirect_url)
 
     except OIDCServiceError as e:


### PR DESCRIPTION
## Summary

Fixes the OIDC callback redirect serving the landing page instead of the SPA after nginx's `location = /` rule was introduced.

After commit b683a43 added a dedicated `location = /` nginx block serving `landing.html`, the OIDC callback redirect to `{frontend_url}/?token={jwt_token}` hit that exact-match rule and served the landing page instead of `index.html` (the SPA). The landing page has no token-handling JavaScript — `main.js` (which extracts `?token` from the URL) is only loaded in `index.html`.

**Fix:** Changed the redirect URL in `backend/src/api/auth.py` from `/?token=...` to `/index.html?token=...` so nginx serves the SPA, and `main.js` correctly picks up the token, stores it in `localStorage`, and completes the authentication flow.

Both the SPA and the legacy login page (`/views/login/login.html`) are covered by this fix.

## Tests

- Existing OIDC E2E tests cover the callback → token extraction flow
- Manual verification of redirect behavior with the updated nginx config

## Risks / Notes

- **Deployment**: Requires rebuilding the backend Docker image and redeploying (Helm upgrade). No nginx config or frontend changes needed.
- **Login page compatibility**: Verified the legacy login page (`/views/login/login.html`) works end-to-end — it redirects to `/api/auth/oidc/{provider}`, the callback redirects to `/index.html?token=...`, and `main.js` handles token extraction.

## Changelog

- Updated `CHANGELOG.md` for v1.16.1.
